### PR TITLE
adding missing # before comment in BrickPi.py

### DIFF
--- a/BrickPi.py
+++ b/BrickPi.py
@@ -32,9 +32,9 @@
 # a message to the RPi. The RPi will then fail to receive a message in the specified amount of time, timeout, and then retry the
 # communication.
 
-If a function returns 0, it completed successfully. If it returns -1, there was an error (most likely a communications error).
+# If a function returns 0, it completed successfully. If it returns -1, there was an error (most likely a communications error).
 
-Function BrickPiRx() (background function that receives UART messages from the BrickPi) can return 0 (success), -1 (undefined error that shouldn't have happened, e.g. a filesystem error), -2 (timeout: the RPi didn't receive any UART communication from the BrickPi within the specified time), -4 (the message was too short to even contain a valid header), -5 (communication checksum error), or -6 (the number of bytes received was less than specified by the length byte).
+# Function BrickPiRx() (background function that receives UART messages from the BrickPi) can return 0 (success), -1 (undefined error that shouldn't have happened, e.g. a filesystem error), -2 (timeout: the RPi didn't receive any UART communication from the BrickPi within the specified time), -4 (the message was too short to even contain a valid header), -5 (communication checksum error), or -6 (the number of bytes received was less than specified by the length byte).
 
 
 import time


### PR DESCRIPTION
Hi.
I'm not a python dev.
But I tried using BrickPi for the first time today and got an error when running the examples.
The error said there's a problem in line 35 in BrickPi.py.
So I took a look and it seems like in the latest commit some text that's not code was not prefixed with a #.
My change is to add this comment identifier.
After I did this the error message was gone.
