### PR TITLE
Fixed a porting bug in BrickPiSetTimeout

### DIFF
--- a/BrickPi.py
+++ b/BrickPi.py
@@ -227,7 +227,6 @@ def BrickPiSetTimeout():
             Array[j] = InArray[j]
         if not (BytesReceived == 1 and Array[BYTE_MSG_TYPE] == MSG_TYPE_TIMEOUT_SETTINGS):
             return -1
-        i+=1
     return 0
 
 def motorRotateDegree(power,deg,port,sampling_time=.1):


### PR DESCRIPTION
That `i += 1` shouldn't be there, it's used in the C version to implement the cycle: https://github.com/DexterInd/BrickPi_C/blob/master/Drivers/BrickPi.h#L282
