### PR TITLE
add future to the list of requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 RPi.GPIO
 pyserial
+future


### PR DESCRIPTION
For those who download directly from github, the `future` library will be installed when `setup.py install` is called.