### PR TITLE
fixed KeyCheck to work in firefox

### DIFF
--- a/Project_Examples/browserBot/Browser_Client_Code.html
+++ b/Project_Examples/browserBot/Browser_Client_Code.html
@@ -187,7 +187,7 @@ function setup2()
 		function arrows()
 		{
 			document.onkeyup = KeyCheck;       
-			function KeyCheck()
+			function KeyCheck(event)
 			{
 				var KeyID = event.keyCode;
 				switch(KeyID)


### PR DESCRIPTION
On firefox KeyCheck() produced errors "ReferenceError: event is not defined error". Adding 'event' as argument fixed that